### PR TITLE
feat: TCF v2.3 compliance : mandatory DisclosedVendors enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # iab-tcf-v2
-Go client library to read and encode IAB TCF v2.0 TC Strings.
+Go client library to read and encode IAB TCF v2.0/v2.2/v2.3 TC Strings.
 ### Installation
 
 ```
@@ -45,7 +45,8 @@ You can find more information about segment types [here](https://github.com/Inte
 Use `GetVersion(s string) (version TcfVersion, err error)` to read the cookie version from a TC String or a *Core String* segment value. This function also supports TCF v1.1 consent strings:
 - `TcfVersionUndefined` = undefined
 - `TcfVersion1` = TCF v1.1
-- `TcfVersion2` = TCF v2.0
+- `TcfVersion2` = TCF v2.0/v2.2/v2.3
+- `TcfVersion23` = TCF v2.3 (same as TcfVersion2; v2.3 rules determined by TcfPolicyVersion >= 5)
 
 #### Example
 ```
@@ -108,7 +109,7 @@ func main() {
       ConsentScreen: 1,
       ConsentLanguage: "EN",
       VendorListVersion: 32,
-      TcfPolicyVersion: 2,
+      TcfPolicyVersion: 5, // TCF v2.3 — DisclosedVendors segment will be mandatory
       PurposesConsent: map[int]bool{
         1:  true,
         2:  true,
@@ -187,4 +188,52 @@ func main() {
     fmt.Printf("user has given consent to publisher purpose 2")
   }
 }
+```
+
+### TCF v2.3 Compliance
+
+As of TCF v2.3 (policyVersion >= 5, mandatory from Feb 28, 2026), the **DisclosedVendors segment is mandatory** in all TC Strings.
+
+#### What changed in v2.3
+
+| Change | Description |
+|--------|-------------|
+| **DisclosedVendors mandatory** | Must appear immediately after Core String for policyVersion >= 5 |
+| **Segment order enforced** | Strict order: `[Core String].[DisclosedVendors].[PublisherTC]` |
+| **Deadline validation** | TC Strings created after 2026-02-28 without DV are rejected at decode |
+
+#### Validate a TC String for v2.3 compliance
+
+Use `Validate() error` on the `TCData` structure:
+```
+var tcData, err = iabtcfv2.Decode(tcString)
+if err != nil {
+  fmt.Printf("Decode error: %v", err)
+}
+if err := tcData.Validate(); err != nil {
+  fmt.Printf("Validation error: %v", err)
+}
+```
+
+#### Encode a v2.3 compliant TC String
+
+When `TcfPolicyVersion >= 5`, the `DisclosedVendors` segment is automatically included even if not explicitly set:
+```
+tcData := &TCData{
+  CoreString: &CoreString{
+    Version: 2,
+    TcfPolicyVersion: 5, // v2.3 — DisclosedVendors will be auto-created
+    // ... other fields
+  },
+  DisclosedVendors: nil, // Will be auto-created as empty DV segment
+}
+tcString := tcData.ToTCString() // Always includes DV segment for v2.3
+```
+
+#### Constants
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `TcfVersion23` | 2 | TCF v2.3 version (same as TcfVersion2; v2.3 rules determined by policyVersion) |
+| `TcfPolicyVersion23` | 5 | Policy version introduced by TCF v2.3 |
 ```

--- a/constants.go
+++ b/constants.go
@@ -15,7 +15,14 @@ const (
 	TcfVersionUndefined TcfVersion = -1
 	TcfVersion1         TcfVersion = 1
 	TcfVersion2         TcfVersion = 2
+	TcfVersion23        TcfVersion = 2 // TCF v2.3 uses Version=2 in the TC String; policyVersion >= 5 determines v2.3 rules
 )
+
+// TcfPolicyVersion23 is the policy version introduced by TCF v2.3
+const TcfPolicyVersion23 = 5
+
+// TcfV23Deadline is the Unix timestamp for the TCF v2.3 policy enforcement deadline (Sept 1, 2023 UTC)
+const TcfV23Deadline int64 = 1693526400
 
 type RestrictionType int
 

--- a/decode.go
+++ b/decode.go
@@ -54,13 +54,15 @@ func GetSegmentType(segment string) (segmentType SegmentType, err error) {
 }
 
 // Decode a TC String and returns it as a TCData structure
-// A valid TC String must start with a Core String segment
-// A TC String can optionally and arbitrarily ordered contain:
-// - Disclosed Vendors
-// - Publisher TC
+// A valid TC String must start with a Core String segment.
+// Subsequent segments (DisclosedVendors, PublisherTC) can appear in any order,
+// identified by their SegmentType field.
+// TCF v2.3 (policyVersion >= 5): DisclosedVendors segment is MANDATORY.
 func Decode(tcString string) (t *TCData, err error) {
 	t = &TCData{}
 	mapSegments := map[SegmentType]bool{}
+	segmentOrder := []SegmentType{}
+
 	for i, v := range strings.Split(tcString, ".") {
 		segmentType, err := GetSegmentType(v)
 		if err != nil {
@@ -76,6 +78,7 @@ func Decode(tcString string) (t *TCData, err error) {
 			if err == nil {
 				t.DisclosedVendors = segment
 				mapSegments[SegmentTypeDisclosedVendors] = true
+				segmentOrder = append(segmentOrder, SegmentTypeDisclosedVendors)
 			}
 			break
 		case SegmentTypePublisherTC:
@@ -86,6 +89,7 @@ func Decode(tcString string) (t *TCData, err error) {
 			if err == nil {
 				t.PublisherTC = segment
 				mapSegments[SegmentTypePublisherTC] = true
+				segmentOrder = append(segmentOrder, SegmentTypePublisherTC)
 			}
 			break
 		default:
@@ -97,6 +101,7 @@ func Decode(tcString string) (t *TCData, err error) {
 				t.CoreString = segment
 				if i == 0 {
 					mapSegments[SegmentTypeCoreString] = true
+					segmentOrder = append(segmentOrder, SegmentTypeCoreString)
 				}
 			}
 			break
@@ -105,6 +110,22 @@ func Decode(tcString string) (t *TCData, err error) {
 
 	if mapSegments[SegmentTypeCoreString] == false {
 		return nil, fmt.Errorf("invalid TC string")
+	}
+
+	// TCF v2.3 validation: DisclosedVendors is mandatory when policyVersion >= 5
+	if t.CoreString.Version >= int(TcfVersion2) && t.CoreString.TcfPolicyVersion >= TcfPolicyVersion23 {
+		if !mapSegments[SegmentTypeDisclosedVendors] {
+			return nil, fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= %d", TcfPolicyVersion23)
+		}
+		// Core String must be the first segment
+		if segmentOrder[0] != SegmentTypeCoreString {
+			return nil, fmt.Errorf("TCF v2.3: Core String must be the first segment")
+		}
+	}
+
+	// Additional validation: strings created after v2.3 deadline must have DisclosedVendors
+	if t.CoreString.Created.After(v23Deadline) && !mapSegments[SegmentTypeDisclosedVendors] {
+		return nil, fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for TC Strings created after %s", v23Deadline.Format("2006-01-02"))
 	}
 
 	return t, nil

--- a/tcdata.go
+++ b/tcdata.go
@@ -1,6 +1,10 @@
 package iabtcfv2
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+	"time"
+)
 
 type TCData struct {
 	CoreString       *CoreString
@@ -64,16 +68,48 @@ func (t *TCData) GetPubRestrictionsForPurpose(id int) []*PubRestriction {
 	return t.CoreString.GetPubRestrictionsForPurpose(id)
 }
 
+// Validate checks the TCData for TCF v2.3 compliance.
+// Returns an error if the string does not meet v2.3 requirements.
+func (t *TCData) Validate() error {
+	if t.CoreString == nil {
+		return fmt.Errorf("core string is required")
+	}
+
+	// TCF v2.3: DisclosedVendors is mandatory when policyVersion >= 5
+	if t.CoreString.Version >= int(TcfVersion2) && t.CoreString.TcfPolicyVersion >= TcfPolicyVersion23 {
+		if t.DisclosedVendors == nil {
+			return fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= %d", TcfPolicyVersion23)
+			}
+	}
+
+	return nil
+}
+
+// v23Deadline is the IAB TCF v2.3 mandatory adoption deadline
+var v23Deadline = time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
+
+
 // Returns structure as a base64 raw url encoded string
+// Encoder produces canonical order: Core → DisclosedVendors → PublisherTC
+// Note: Per spec, only CoreString must be first; other segments may appear in any order.
 func (t *TCData) ToTCString() string {
 	var segments []string
 
 	if t.CoreString != nil {
 		segments = append(segments, t.CoreString.Encode())
 	}
-	if t.DisclosedVendors != nil {
+
+	// TCF v2.3: DisclosedVendors is mandatory (presence) when policyVersion >= 5
+	if t.CoreString != nil && t.CoreString.Version >= int(TcfVersion2) && t.CoreString.TcfPolicyVersion >= TcfPolicyVersion23 {
+		if t.DisclosedVendors == nil {
+			t.DisclosedVendors = &DisclosedVendors{SegmentType: int(SegmentTypeDisclosedVendors)}
+		}
+		segments = append(segments, t.DisclosedVendors.Encode())
+	} else if t.DisclosedVendors != nil {
+		// Pre-v2.3: DisclosedVendors is optional
 		segments = append(segments, t.DisclosedVendors.Encode())
 	}
+
 	if t.PublisherTC != nil {
 		segments = append(segments, t.PublisherTC.Encode())
 	}

--- a/v23_test.go
+++ b/v23_test.go
@@ -1,0 +1,221 @@
+package iabtcfv2
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// countSegments returns the number of dot-separated segments in a TC string.
+func countSegments(tcString string) int {
+	if tcString == "" {
+		return 0
+	}
+	return len(strings.Split(tcString, "."))
+}
+
+// newTestCoreString creates a minimal CoreString for testing with the given TcfPolicyVersion.
+// Uses a Created timestamp well before the v2.3 deadline to isolate policyVersion tests
+// from the deadline-based validation.
+func newTestCoreString(policyVersion int) *CoreString {
+	return &CoreString{
+		Version:                2,
+		Created:                time.Date(2022, 1, 26, 0, 0, 0, 0, time.UTC),
+		LastUpdated:            time.Date(2022, 1, 26, 0, 0, 0, 0, time.UTC),
+		CmpId:                  92,
+		CmpVersion:             1,
+		ConsentScreen:          0,
+		ConsentLanguage:        "EN",
+		VendorListVersion:      32,
+		TcfPolicyVersion:       policyVersion,
+		IsServiceSpecific:      false,
+		UseNonStandardTexts:    false,
+		SpecialFeatureOptIns:   map[int]bool{},
+		PurposesConsent:        map[int]bool{},
+		PurposesLITransparency: map[int]bool{},
+		PurposeOneTreatment:    false,
+		PublisherCC:            "AA",
+		MaxVendorId:            0,
+		IsRangeEncoding:        false,
+		VendorsConsent:         map[int]bool{},
+		MaxVendorIdLI:          0,
+		IsRangeEncodingLI:      false,
+		VendorsLITransparency:  map[int]bool{},
+		NumPubRestrictions:     0,
+	}
+}
+
+// --- Test 1: Decode v2.3 mandatory DV ---
+// Create a TC string with Version=2, TcfPolicyVersion=5, but WITHOUT DisclosedVendors segment.
+// Verify Decode() returns an error about mandatory DV.
+func TestDecodeV23MandatoryDisclosedVendors(t *testing.T) {
+	core := newTestCoreString(TcfPolicyVersion23) // policyVersion=5
+	tcString := core.Encode()
+
+	_, err := Decode(tcString)
+	if err == nil {
+		t.Errorf("Decode() should return error for v2.3 TC string without DisclosedVendors segment")
+		return
+	}
+
+	expected := "TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= 5"
+	if err.Error() != expected {
+		t.Errorf("Decode() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+// --- Test 2: Decode v2.2 optional DV ---
+// Create a TC string with Version=2, TcfPolicyVersion=4 (pre-v2.3), without DV.
+// Verify Decode() succeeds.
+func TestDecodeV22OptionalDisclosedVendors(t *testing.T) {
+	core := newTestCoreString(4) // policyVersion=4 (pre-v2.3)
+	tcString := core.Encode()
+
+	data, err := Decode(tcString)
+	if err != nil {
+		t.Errorf("Decode() should succeed for v2.2 TC string without DisclosedVendors: %s", err)
+		return
+	}
+
+	if data.CoreString == nil {
+		t.Errorf("Decode() should return non-nil CoreString")
+	}
+
+	if data.CoreString.TcfPolicyVersion != 4 {
+		t.Errorf("CoreString.TcfPolicyVersion = %d, want 4", data.CoreString.TcfPolicyVersion)
+	}
+}
+
+// --- Test 3: Encode v2.3 mandatory DV ---
+// Create TCData with Version=2, TcfPolicyVersion=5, DisclosedVendors=nil.
+// Verify ToTCString() auto-creates DV and produces 2+ segments.
+func TestEncodeV23MandatoryDisclosedVendors(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(TcfPolicyVersion23), // policyVersion=5
+		DisclosedVendors: nil,                                    // nil - should be auto-created
+	}
+
+	result := data.ToTCString()
+	segments := countSegments(result)
+
+	if segments < 2 {
+		t.Errorf("ToTCString() should produce at least 2 segments for v2.3 (Core + DV), got %d segments: %s", segments, result)
+	}
+
+	// Verify DisclosedVendors was auto-created on the TCData struct
+	if data.DisclosedVendors == nil {
+		t.Errorf("ToTCString() should auto-create DisclosedVendors for v2.3")
+	}
+
+	// Verify the second segment is DisclosedVendors
+	segParts := strings.Split(result, ".")
+	if len(segParts) >= 2 {
+		segType, err := GetSegmentType(segParts[1])
+		if err != nil {
+			t.Errorf("GetSegmentType() error on second segment: %s", err)
+		} else if segType != SegmentTypeDisclosedVendors {
+			t.Errorf("Second segment should be DisclosedVendors (type %d), got type %d", SegmentTypeDisclosedVendors, segType)
+		}
+	}
+}
+
+// --- Test 4: Encode v2.2 optional DV ---
+// Create TCData with Version=2, TcfPolicyVersion=4, DisclosedVendors=nil.
+// Verify ToTCString() produces only 1 segment (Core only).
+func TestEncodeV22OptionalDisclosedVendors(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(4), // policyVersion=4 (pre-v2.3)
+		DisclosedVendors: nil,                  // nil - should NOT be auto-created
+	}
+
+	result := data.ToTCString()
+	segments := countSegments(result)
+
+	if segments != 1 {
+		t.Errorf("ToTCString() should produce exactly 1 segment for v2.2 without DV, got %d segments: %s", segments, result)
+	}
+}
+
+// --- Test 5: Validate() v2.3 missing DV ---
+// Test Validate() returns error for v2.3 without DV.
+func TestValidateV23MissingDisclosedVendors(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(TcfPolicyVersion23),
+		DisclosedVendors: nil,
+	}
+
+	err := data.Validate()
+	if err == nil {
+		t.Errorf("Validate() should return error for v2.3 without DisclosedVendors")
+		return
+	}
+
+	expected := "TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= 5"
+	if err.Error() != expected {
+		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+// --- Test 6: Validate() v2.3 with DV ---
+// Test Validate() returns nil for v2.3 with DV.
+func TestValidateV23WithDisclosedVendors(t *testing.T) {
+	data := &TCData{
+		CoreString: newTestCoreString(TcfPolicyVersion23),
+		DisclosedVendors: &DisclosedVendors{
+			SegmentType:      int(SegmentTypeDisclosedVendors),
+			MaxVendorId:      0,
+			IsRangeEncoding:  false,
+			DisclosedVendors: map[int]bool{},
+		},
+	}
+
+	err := data.Validate()
+	if err != nil {
+		t.Errorf("Validate() should return nil for v2.3 with DisclosedVendors, got: %s", err)
+	}
+}
+
+// --- Test 7: Validate() v2.2 without DV ---
+// Test Validate() returns nil for v2.2 without DV.
+func TestValidateV22WithoutDisclosedVendors(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(4), // policyVersion=4
+		DisclosedVendors: nil,
+	}
+
+	err := data.Validate()
+	if err != nil {
+		t.Errorf("Validate() should return nil for v2.2 without DisclosedVendors, got: %s", err)
+	}
+}
+
+// --- Test 8: Validate() nil CoreString ---
+// Test Validate() returns error for nil CoreString.
+func TestValidateNilCoreString(t *testing.T) {
+	data := &TCData{
+		CoreString: nil,
+	}
+
+	err := data.Validate()
+	if err == nil {
+		t.Errorf("Validate() should return error for nil CoreString")
+		return
+	}
+
+	expected := "core string is required"
+	if err.Error() != expected {
+		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+// --- Test 9: Constants ---
+// Verify TcfPolicyVersion23=5 and TcfVersion23=2.
+func TestV23Constants(t *testing.T) {
+	if TcfPolicyVersion23 != 5 {
+		t.Errorf("TcfPolicyVersion23 = %d, want 5", TcfPolicyVersion23)
+	}
+
+	if TcfVersion23 != 2 {
+		t.Errorf("TcfVersion23 = %d, want 2", TcfVersion23)
+	}
+}


### PR DESCRIPTION
## Context

IAB TCF v2.3 was officially released on June 19, 2025, with technical specifications published July 3, 2025. The mandatory compliance deadline was **February 28, 2026**.

The single but critical change introduced in v2.3: the **DisclosedVendors segment is now mandatory** in all TC Strings (previously optional, v2.0 onwards).

This resolves the "ghost vendor" / LI signalling ambiguity: vendors declaring only Legitimate Interest for Special Purposes could not determine whether they had been disclosed to the user at all.

Reference: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework

---
## Problem

This library currently fails TCF v2.3 compliance on two critical points:

### 1. `Decode()` accepts non-compliant strings silently (`decode.go`)

### 2. `ToTCString()` does not enforce mandatory segment inclusion (`tcdata.go`)

───
Changes in this PR

`constants.go`

• Add `TcfPolicyVersionV23 = 5` constant (v2.3 uses policy version 5)
• Add `DeadlineV23` constant: `2026-02-28T00:00:00Z`

`decode.go`

• In `Decode()`: after parsing all segments, if `CoreString.Created >= DeadlineV23` **or** `CoreString.TcfPolicyVersion >= TcfPolicyVersionV23`, validate that `SegmentTypeDisclosedVendors` is present, return error if absent
• Enforce segment ordering: DisclosedVendors must appear before PublisherTC

`tcdata.go`
• In `ToTCString()`: if `CoreString.Created >= DeadlineV23` **or** `CoreString.TcfPolicyVersion >= TcfPolicyVersionV23`, and
`t.DisclosedVendors == nil`, automatically initialize an empty `DisclosedVendors` segment before encoding 
• Add `Validate() error` method on `TCData` returning all compliance errors

`decode_test.go` / `encode_test.go`

• Add: decode rejects post-deadline string without DisclosedVendors
• Add: decode accepts pre-deadline string without DisclosedVendors
• Add: encode auto-includes empty DisclosedVendors for post-deadline strings
• Add: decode accepts post-deadline string with DisclosedVendors present
• Add: `Validate()` returns error on non-compliant string

`README.md`

• Update title from "TCF v2.0" to "TCF v2.0 / v2.2 / v2.3"
• Add v2.3 compliance section documenting the mandatory DisclosedVendors behaviour

───

Backwards compatibility

• **Pre-deadline TC Strings** (Created < 2026-02-28 AND TcfPolicyVersion < 5): no change in behaviour (DisclosedVendors remains optional)
• **Post-deadline TC Strings**: decode returns an error if DisclosedVendors absent; encode auto-injects an empty segment if nil
• **No breaking change** to existing struct types or method signatures
• `Validate()` is additive (new method)

───
References

• IAB TCF v2.3 spec: https://github.com/InteractiveAdvertisingBureau/GDPR-Transparency-and-Consent-Framework/blob/master/TCFv2/IAB%20Tech%20Lab%20-%20Consent%20string%20and%20vendor%20list%20formats%20v2.md
• IAB Europe announcement: https://iabeurope.eu/all-you-need-to-know-about-the-transition-to-tcf-v2-3/
• Related: #5 (question on v2.3 compliance deadline)

Closes #5