### PR TITLE
feat: TCF v2.3 minor fixes + DecodeLenient for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,39 @@ The package defines a `TCData` structure with the three segments a TC String can
 
 To decode a TC String, use `Decode(tcString string) (t *TCData, err error)`.
 
+`Decode()` enforces TCF v2.3 compliance rules: TC Strings created after **February 28, 2026** must have `TcfPolicyVersion >= 5` and include a `DisclosedVendors` segment. Strings that do not meet these requirements are rejected with an error.
+
+Use this function in **production** to validate user consent before processing personal data.
+
 NOTE : A valid TC String must start with a *Core String* segment value.
 ```
 var tcData, err = iabtcfv2.Decode("COxR03kOxR1CqBcABCENAgCMAP_AAH_AAAqIF3EXySoGY2thI2YVFxBEIYwfJxyigMgChgQIsSwNQIeFLBoGLiAAHBGYJAQAGBAEEACBAQIkHGBMCQAAgAgBiRCMQEGMCzNIBIBAggEbY0FACCVmHkHSmZCY7064O__QLuIJEFQMAkSBAIACLECIQwAQDiAAAYAlAAABAhIaAAgIWBQEeAAAACAwAAgAAABBAAACAAQAAICIAAABAAAgAiAQAAAAGgIQAACBABACRIAAAEANCAAgiCEAQg4EAo4AAA.IF3EXySoGY2tho2YVFzBEIYwfJxyigMgShgQIsS0NQIeFLBoGPiAAHBGYJAQAGBAkkACBAQIsHGBMCQABgAgRiRCMQEGMDzNIBIBAggkbY0FACCVmnkHS3ZCY70-6u__QA.elAAAAAAAWA")
 if err != nil {
   fmt.Printf("%v", err)
+}
+```
+
+#### DecodeLenient — for debugging and analysis only
+
+> ⚠️ **`DecodeLenient()` is NOT suitable for production consent checking.**
+> It bypasses TCF v2.3 compliance rules and will accept TC Strings that are
+> invalid under the current policy (e.g. missing `DisclosedVendors` segment,
+> `TcfPolicyVersion < 5` after the deadline). Only use it for debugging,
+> logging, or forensic analysis where you need to inspect the contents of a
+> non-compliant TC String. **Never use it to decide whether to process user data.**
+
+```
+// DecodeLenient: extracts TC data regardless of v2.3 compliance.
+// Use ONLY for debugging/analysis — never for consent decisions in production.
+tcData, err := iabtcfv2.DecodeLenient(tcString)
+if err != nil {
+  // format is completely invalid — not a TC string at all
+  fmt.Printf("%v", err)
+}
+
+// If you need to check compliance separately:
+if err := tcData.Validate(); err != nil {
+  fmt.Printf("Non-compliant: %v", err)
 }
 ```
 
@@ -192,19 +220,31 @@ func main() {
 
 ### TCF v2.3 Compliance
 
-As of TCF v2.3 (policyVersion >= 5, mandatory from Feb 28, 2026), the **DisclosedVendors segment is mandatory** in all TC Strings.
+As of TCF v2.3 (policyVersion >= 5, mandatory from Feb 28, 2026), the following rules apply:
+
+#### Decode() enforcement policy
+
+| TC String creation date | TcfPolicyVersion | Has DisclosedVendors? | `Decode()` result |
+|------------------------|------------------|----------------------|-------------------|
+| Before March 1, 2026 | Any | Any | ✅ Valid |
+| After Feb 28, 2026 | >= 5 | Yes | ✅ Valid |
+| After Feb 28, 2026 | >= 5 | No | ❌ Invalid |
+| After Feb 28, 2026 | < 5 | Any | ❌ Invalid |
+
+**`DecodeLenient()`** bypasses these checks — see warning above.
 
 #### What changed in v2.3
 
 | Change | Description |
 |--------|-------------|
-| **DisclosedVendors mandatory** | Must appear immediately after Core String for policyVersion >= 5 |
+| **DisclosedVendors mandatory** | Must appear immediately after Core String for TC Strings created after Feb 28, 2026 |
+| **Deadline validation** | TC Strings created after 2026-02-28 without DV or with `TcfPolicyVersion < 5` are rejected by `Decode()` |
+| **Purpose 1 LI restricted** | `IsPurposeLIAllowed(1)` returns `false` for v2.3 strings — Purpose 1 cannot be established via legitimate interest |
 | **Segment order enforced** | Strict order: `[Core String].[DisclosedVendors].[PublisherTC]` |
-| **Deadline validation** | TC Strings created after 2026-02-28 without DV are rejected at decode |
 
 #### Validate a TC String for v2.3 compliance
 
-Use `Validate() error` on the `TCData` structure:
+Use `Validate() error` on the `TCData` structure. `Validate()` applies the same deadline-based rules as `Decode()`:
 ```
 var tcData, err = iabtcfv2.Decode(tcString)
 if err != nil {
@@ -212,6 +252,24 @@ if err != nil {
 }
 if err := tcData.Validate(); err != nil {
   fmt.Printf("Validation error: %v", err)
+}
+```
+
+#### Check if a TC String follows v2.3 rules
+
+Use `IsV23() bool` on the `TCData` structure:
+```
+if tcData.IsV23() {
+  // TcfPolicyVersion >= 5 — v2.3 rules apply
+}
+```
+
+#### Check if a vendor is disclosed
+
+Use `IsVendorDisclosed(id int) bool` on the `TCData` structure:
+```
+if tcData.IsVendorDisclosed(42) {
+  // vendor 42 is present in the DisclosedVendors segment
 }
 ```
 
@@ -236,4 +294,4 @@ tcString := tcData.ToTCString() // Always includes DV segment for v2.3
 |----------|-------|-------------|
 | `TcfVersion23` | 2 | TCF v2.3 version (same as TcfVersion2; v2.3 rules determined by policyVersion) |
 | `TcfPolicyVersion23` | 5 | Policy version introduced by TCF v2.3 |
-```
+| `TcfV23Deadline` | 1772236800 | Unix timestamp for TCF v2.3 enforcement deadline (Feb 28, 2026 00:00:00 UTC) |

--- a/constants.go
+++ b/constants.go
@@ -21,8 +21,8 @@ const (
 // TcfPolicyVersion23 is the policy version introduced by TCF v2.3
 const TcfPolicyVersion23 = 5
 
-// TcfV23Deadline is the Unix timestamp for the TCF v2.3 policy enforcement deadline (Sept 1, 2023 UTC)
-const TcfV23Deadline int64 = 1693526400
+// TcfV23Deadline is the Unix timestamp for the TCF v2.3 policy enforcement deadline (Feb 28, 2026 00:00:00 UTC)
+const TcfV23Deadline int64 = 1772236800
 
 type RestrictionType int
 

--- a/decode.go
+++ b/decode.go
@@ -112,10 +112,14 @@ func Decode(tcString string) (t *TCData, err error) {
 		return nil, fmt.Errorf("invalid TC string")
 	}
 
-	// TCF v2.3 validation: DisclosedVendors is mandatory when policyVersion >= 5
-	if t.CoreString.Version >= int(TcfVersion2) && t.CoreString.TcfPolicyVersion >= TcfPolicyVersion23 {
+	// TCF v2.3: After Feb 28, 2026, TC strings must have TcfPolicyVersion >= 5
+	// AND a DisclosedVendors segment. Before March 1, 2026, DV is optional.
+	if t.CoreString.Created.After(v23Deadline) {
+		if t.CoreString.TcfPolicyVersion < TcfPolicyVersion23 {
+			return nil, fmt.Errorf("TCF v2.3: TC Strings created after %s must have policyVersion >= %d", v23Deadline.Format("2006-01-02"), TcfPolicyVersion23)
+		}
 		if !mapSegments[SegmentTypeDisclosedVendors] {
-			return nil, fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= %d", TcfPolicyVersion23)
+			return nil, fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for TC Strings created after %s", v23Deadline.Format("2006-01-02"))
 		}
 		// Core String must be the first segment
 		if segmentOrder[0] != SegmentTypeCoreString {
@@ -123,13 +127,67 @@ func Decode(tcString string) (t *TCData, err error) {
 		}
 	}
 
-	// Additional validation: strings created after v2.3 deadline must have DisclosedVendors
-	if t.CoreString.Created.After(v23Deadline) && !mapSegments[SegmentTypeDisclosedVendors] {
-		return nil, fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for TC Strings created after %s", v23Deadline.Format("2006-01-02"))
-	}
-
 	return t, nil
 }
+
+// DecodeLenient decodes a TC String without enforcing TCF v2.3 deadline/policyVersion checks.
+// Accepts any well-formed TC string regardless of creation date or policy version.
+func DecodeLenient(tcString string) (t *TCData, err error) {
+	t = &TCData{}
+	mapSegments := map[SegmentType]bool{}
+	segmentOrder := []SegmentType{}
+
+	for i, v := range strings.Split(tcString, ".") {
+		segmentType, err := GetSegmentType(v)
+		if err != nil {
+			return nil, err
+		}
+
+		switch segmentType {
+		case SegmentTypeDisclosedVendors:
+			if mapSegments[SegmentTypeDisclosedVendors] {
+				return nil, fmt.Errorf("duplicate Disclosed Vendors segment")
+			}
+			segment, err := DecodeDisclosedVendors(v)
+			if err == nil {
+				t.DisclosedVendors = segment
+				mapSegments[SegmentTypeDisclosedVendors] = true
+				segmentOrder = append(segmentOrder, SegmentTypeDisclosedVendors)
+			}
+		case SegmentTypePublisherTC:
+			if mapSegments[SegmentTypePublisherTC] {
+				return nil, fmt.Errorf("duplicate Publisher TC segment")
+			}
+			segment, err := DecodePublisherTC(v)
+			if err == nil {
+				t.PublisherTC = segment
+				mapSegments[SegmentTypePublisherTC] = true
+				segmentOrder = append(segmentOrder, SegmentTypePublisherTC)
+			}
+		default:
+			if mapSegments[SegmentTypeCoreString] {
+				return nil, fmt.Errorf("duplicate Core String segment")
+			}
+			segment, err := DecodeCoreString(v)
+			if err == nil {
+				t.CoreString = segment
+				if i == 0 {
+					mapSegments[SegmentTypeCoreString] = true
+					segmentOrder = append(segmentOrder, SegmentTypeCoreString)
+				}
+			}
+		}
+	}
+
+	if !mapSegments[SegmentTypeCoreString] {
+		return nil, fmt.Errorf("invalid TC string")
+	}
+
+	// NO deadline/policyVersion checks — lenient mode
+	_ = segmentOrder
+	return t, nil
+}
+
 
 // Decodes a Core String value and returns it as a CoreString structure
 func DecodeCoreString(coreString string) (c *CoreString, err error) {

--- a/segment_core_string.go
+++ b/segment_core_string.go
@@ -79,8 +79,11 @@ func (c *CoreString) IsPurposeAllowed(id int) bool {
 }
 
 // Returns true if legitimate interest is established for purpose id
-// and user didn't exercise their right to object
 func (c *CoreString) IsPurposeLIAllowed(id int) bool {
+	// TCF v2.3: Purpose 1 cannot be established via legitimate interest
+	if id == 1 && c.TcfPolicyVersion >= TcfPolicyVersion23 {
+		return false
+	}
 	return c.PurposesLITransparency[id]
 }
 

--- a/tcdata.go
+++ b/tcdata.go
@@ -68,6 +68,22 @@ func (t *TCData) GetPubRestrictionsForPurpose(id int) []*PubRestriction {
 	return t.CoreString.GetPubRestrictionsForPurpose(id)
 }
 
+// IsVendorDisclosed returns true if the given vendor ID is in the DisclosedVendors segment.
+func (t *TCData) IsVendorDisclosed(id int) bool {
+	if t.DisclosedVendors == nil {
+		return false
+	}
+	return t.DisclosedVendors.IsVendorDisclosed(id)
+}
+
+// IsV23 returns true if the TC string uses TCF v2.3 policy (TcfPolicyVersion >= 5).
+func (t *TCData) IsV23() bool {
+	if t.CoreString == nil {
+		return false
+	}
+	return t.CoreString.TcfPolicyVersion >= TcfPolicyVersion23
+}
+
 // Validate checks the TCData for TCF v2.3 compliance.
 // Returns an error if the string does not meet v2.3 requirements.
 func (t *TCData) Validate() error {
@@ -75,18 +91,21 @@ func (t *TCData) Validate() error {
 		return fmt.Errorf("core string is required")
 	}
 
-	// TCF v2.3: DisclosedVendors is mandatory when policyVersion >= 5
-	if t.CoreString.Version >= int(TcfVersion2) && t.CoreString.TcfPolicyVersion >= TcfPolicyVersion23 {
+	// After the deadline: TcfPolicyVersion >= 5 AND DisclosedVendors required
+	if t.CoreString.Created.After(v23Deadline) {
+		if t.CoreString.TcfPolicyVersion < TcfPolicyVersion23 {
+			return fmt.Errorf("TCF v2.3: TC Strings created after %s must have policyVersion >= %d", v23Deadline.Format("2006-01-02"), TcfPolicyVersion23)
+		}
 		if t.DisclosedVendors == nil {
-			return fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= %d", TcfPolicyVersion23)
-			}
+			return fmt.Errorf("TCF v2.3: DisclosedVendors segment is mandatory for TC Strings created after %s", v23Deadline.Format("2006-01-02"))
+		}
 	}
 
 	return nil
 }
 
 // v23Deadline is the IAB TCF v2.3 mandatory adoption deadline
-var v23Deadline = time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
+var v23Deadline = time.Unix(TcfV23Deadline, 0).UTC()
 
 
 // Returns structure as a base64 raw url encoded string

--- a/v23_test.go
+++ b/v23_test.go
@@ -15,8 +15,6 @@ func countSegments(tcString string) int {
 }
 
 // newTestCoreString creates a minimal CoreString for testing with the given TcfPolicyVersion.
-// Uses a Created timestamp well before the v2.3 deadline to isolate policyVersion tests
-// from the deadline-based validation.
 func newTestCoreString(policyVersion int) *CoreString {
 	return &CoreString{
 		Version:                2,
@@ -45,54 +43,404 @@ func newTestCoreString(policyVersion int) *CoreString {
 	}
 }
 
-// --- Test 1: Decode v2.3 mandatory DV ---
-// Create a TC string with Version=2, TcfPolicyVersion=5, but WITHOUT DisclosedVendors segment.
-// Verify Decode() returns an error about mandatory DV.
-func TestDecodeV23MandatoryDisclosedVendors(t *testing.T) {
-	core := newTestCoreString(TcfPolicyVersion23) // policyVersion=5
+// newTestCoreStringAfterDeadline creates a CoreString with Created after the v2.3 deadline.
+func newTestCoreStringAfterDeadline(policyVersion int) *CoreString {
+	return &CoreString{
+		Version:                2,
+		Created:                time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC), // After Feb 28, 2026
+		LastUpdated:            time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+		CmpId:                  92,
+		CmpVersion:             1,
+		ConsentScreen:          0,
+		ConsentLanguage:        "EN",
+		VendorListVersion:      32,
+		TcfPolicyVersion:       policyVersion,
+		IsServiceSpecific:      false,
+		UseNonStandardTexts:    false,
+		SpecialFeatureOptIns:   map[int]bool{},
+		PurposesConsent:        map[int]bool{},
+		PurposesLITransparency: map[int]bool{},
+		PurposeOneTreatment:    false,
+		PublisherCC:            "AA",
+		MaxVendorId:            0,
+		IsRangeEncoding:        false,
+		VendorsConsent:         map[int]bool{},
+		MaxVendorIdLI:          0,
+		IsRangeEncodingLI:      false,
+		VendorsLITransparency:  map[int]bool{},
+		NumPubRestrictions:     0,
+	}
+}
+
+// --- Decode() deadline-based policy tests ---
+
+// Test: Decode v2.3 TC string created BEFORE deadline without DV → ✅ should succeed
+func TestDecodeV23BeforeDeadlineWithoutDV(t *testing.T) {
+	core := newTestCoreString(TcfPolicyVersion23) // policyVersion=5, created=2022 (before deadline)
+	tcString := core.Encode()
+
+	data, err := Decode(tcString)
+	if err != nil {
+		t.Errorf("Decode() should succeed for v2.3 TC string before deadline without DV: %s", err)
+		return
+	}
+	if data.CoreString == nil {
+		t.Errorf("Decode() should return non-nil CoreString")
+	}
+	if data.CoreString.TcfPolicyVersion != TcfPolicyVersion23 {
+		t.Errorf("CoreString.TcfPolicyVersion = %d, want %d", data.CoreString.TcfPolicyVersion, TcfPolicyVersion23)
+	}
+}
+
+// Test: Decode v2.3 TC string created AFTER deadline without DV → ❌ should fail
+func TestDecodeV23AfterDeadlineWithoutDV(t *testing.T) {
+	core := newTestCoreStringAfterDeadline(TcfPolicyVersion23) // policyVersion=5, created=2026-03-01 (after deadline)
 	tcString := core.Encode()
 
 	_, err := Decode(tcString)
 	if err == nil {
-		t.Errorf("Decode() should return error for v2.3 TC string without DisclosedVendors segment")
+		t.Errorf("Decode() should return error for v2.3 TC string after deadline without DV")
 		return
 	}
-
-	expected := "TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= 5"
+	expected := "TCF v2.3: DisclosedVendors segment is mandatory for TC Strings created after 2026-02-28"
 	if err.Error() != expected {
 		t.Errorf("Decode() error = %q, want %q", err.Error(), expected)
 	}
 }
 
-// --- Test 2: Decode v2.2 optional DV ---
-// Create a TC string with Version=2, TcfPolicyVersion=4 (pre-v2.3), without DV.
-// Verify Decode() succeeds.
-func TestDecodeV22OptionalDisclosedVendors(t *testing.T) {
-	core := newTestCoreString(4) // policyVersion=4 (pre-v2.3)
+// Test: Decode v2.3 TC string created AFTER deadline with DV → ✅ should succeed
+func TestDecodeV23AfterDeadlineWithDV(t *testing.T) {
+	core := newTestCoreStringAfterDeadline(TcfPolicyVersion23)
+	data := &TCData{
+		CoreString: core,
+		DisclosedVendors: &DisclosedVendors{
+			SegmentType:      int(SegmentTypeDisclosedVendors),
+			MaxVendorId:      0,
+			IsRangeEncoding:  false,
+			DisclosedVendors: map[int]bool{},
+		},
+	}
+	tcString := data.ToTCString()
+
+	decoded, err := Decode(tcString)
+	if err != nil {
+		t.Errorf("Decode() should succeed for v2.3 TC string after deadline with DV: %s", err)
+		return
+	}
+	if decoded.DisclosedVendors == nil {
+		t.Errorf("Decode() should return non-nil DisclosedVendors")
+	}
+}
+
+// Test: Decode v2.2 TC string (policyVersion=4) created AFTER deadline → ❌ should fail
+func TestDecodeV22AfterDeadline(t *testing.T) {
+	core := newTestCoreStringAfterDeadline(4) // policyVersion=4, created after deadline
+	tcString := core.Encode()
+
+	_, err := Decode(tcString)
+	if err == nil {
+		t.Errorf("Decode() should return error for v2.2 TC string created after deadline")
+		return
+	}
+	expected := "TCF v2.3: TC Strings created after 2026-02-28 must have policyVersion >= 5"
+	if err.Error() != expected {
+		t.Errorf("Decode() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+// Test: Decode v2.2 TC string created BEFORE deadline without DV → ✅ should succeed
+func TestDecodeV22BeforeDeadlineWithoutDV(t *testing.T) {
+	core := newTestCoreString(4) // policyVersion=4, created before deadline
 	tcString := core.Encode()
 
 	data, err := Decode(tcString)
 	if err != nil {
-		t.Errorf("Decode() should succeed for v2.2 TC string without DisclosedVendors: %s", err)
+		t.Errorf("Decode() should succeed for v2.2 TC string before deadline without DV: %s", err)
 		return
 	}
-
-	if data.CoreString == nil {
-		t.Errorf("Decode() should return non-nil CoreString")
-	}
-
 	if data.CoreString.TcfPolicyVersion != 4 {
 		t.Errorf("CoreString.TcfPolicyVersion = %d, want 4", data.CoreString.TcfPolicyVersion)
 	}
 }
 
-// --- Test 3: Encode v2.3 mandatory DV ---
-// Create TCData with Version=2, TcfPolicyVersion=5, DisclosedVendors=nil.
-// Verify ToTCString() auto-creates DV and produces 2+ segments.
+// --- IsVendorDisclosed tests ---
+
+// Test: IsVendorDisclosed with bitfield
+func TestIsVendorDisclosedBitfield(t *testing.T) {
+	d := &DisclosedVendors{
+		IsRangeEncoding:  false,
+		MaxVendorId:      10,
+		DisclosedVendors: map[int]bool{1: true, 3: true, 7: true},
+	}
+	if !d.IsVendorDisclosed(1) {
+		t.Errorf("IsVendorDisclosed(1) should be true")
+	}
+	if !d.IsVendorDisclosed(3) {
+		t.Errorf("IsVendorDisclosed(3) should be true")
+	}
+	if d.IsVendorDisclosed(2) {
+		t.Errorf("IsVendorDisclosed(2) should be false")
+	}
+	if d.IsVendorDisclosed(5) {
+		t.Errorf("IsVendorDisclosed(5) should be false")
+	}
+}
+
+// Test: IsVendorDisclosed with range encoding
+func TestIsVendorDisclosedRangeEncoding(t *testing.T) {
+	d := &DisclosedVendors{
+		IsRangeEncoding: true,
+		RangeEntries: []*RangeEntry{
+			{StartVendorID: 1, EndVendorID: 5},
+			{StartVendorID: 10, EndVendorID: 10},
+		},
+	}
+	if !d.IsVendorDisclosed(1) {
+		t.Errorf("IsVendorDisclosed(1) should be true (in range 1-5)")
+	}
+	if !d.IsVendorDisclosed(5) {
+		t.Errorf("IsVendorDisclosed(5) should be true (in range 1-5)")
+	}
+	if !d.IsVendorDisclosed(10) {
+		t.Errorf("IsVendorDisclosed(10) should be true (single entry)")
+	}
+	if d.IsVendorDisclosed(6) {
+		t.Errorf("IsVendorDisclosed(6) should be false (not in any range)")
+	}
+	if d.IsVendorDisclosed(9) {
+		t.Errorf("IsVendorDisclosed(9) should be false (not in any range)")
+	}
+}
+
+// Test: IsVendorDisclosed nil DisclosedVendors → false
+func TestIsVendorDisclosedNil(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(5),
+		DisclosedVendors: nil,
+	}
+	if data.IsVendorDisclosed(1) {
+		t.Errorf("IsVendorDisclosed(1) should be false when DisclosedVendors is nil")
+	}
+}
+
+// --- IsPurposeLIAllowed(1) tests ---
+
+// Test: IsPurposeLIAllowed(1) with v2.3 → false
+func TestIsPurposeLIAllowed1WithV23(t *testing.T) {
+	core := &CoreString{
+		TcfPolicyVersion:       5,
+		PurposesLITransparency: map[int]bool{1: true, 2: true},
+	}
+	if core.IsPurposeLIAllowed(1) {
+		t.Errorf("IsPurposeLIAllowed(1) should be false for v2.3 (policyVersion=5), even if bit is set")
+	}
+}
+
+// Test: IsPurposeLIAllowed(1) with v2.2 → PurposesLITransparency[1]
+func TestIsPurposeLIAllowed1WithV22(t *testing.T) {
+	core := &CoreString{
+		TcfPolicyVersion:       4,
+		PurposesLITransparency: map[int]bool{1: true, 2: true},
+	}
+	if !core.IsPurposeLIAllowed(1) {
+		t.Errorf("IsPurposeLIAllowed(1) should be true for v2.2 (policyVersion=4) when bit is set")
+	}
+}
+
+// Test: IsPurposeLIAllowed(2) with v2.3 → PurposesLITransparency[2]
+func TestIsPurposeLIAllowed2WithV23(t *testing.T) {
+	core := &CoreString{
+		TcfPolicyVersion:       5,
+		PurposesLITransparency: map[int]bool{1: true, 2: true},
+	}
+	if !core.IsPurposeLIAllowed(2) {
+		t.Errorf("IsPurposeLIAllowed(2) should be true for v2.3 when bit is set")
+	}
+}
+
+// --- IsV23() helper tests ---
+
+// Test: IsV23() helper
+func TestIsV23(t *testing.T) {
+	dataV23 := &TCData{CoreString: &CoreString{TcfPolicyVersion: 5}}
+	if !dataV23.IsV23() {
+		t.Errorf("IsV23() should be true for policyVersion=5")
+	}
+
+	dataV22 := &TCData{CoreString: &CoreString{TcfPolicyVersion: 4}}
+	if dataV22.IsV23() {
+		t.Errorf("IsV23() should be false for policyVersion=4")
+	}
+
+	dataNil := &TCData{CoreString: nil}
+	if dataNil.IsV23() {
+		t.Errorf("IsV23() should be false for nil CoreString")
+	}
+}
+
+// --- Validate() tests ---
+
+// Test: Validate() matches Decode() policy
+func TestValidateV23AfterDeadlineWithoutDV(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreStringAfterDeadline(TcfPolicyVersion23),
+		DisclosedVendors: nil,
+	}
+	err := data.Validate()
+	if err == nil {
+		t.Errorf("Validate() should return error for v2.3 after deadline without DV")
+		return
+	}
+	expected := "TCF v2.3: DisclosedVendors segment is mandatory for TC Strings created after 2026-02-28"
+	if err.Error() != expected {
+		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestValidateV23AfterDeadlineWithDV(t *testing.T) {
+	data := &TCData{
+		CoreString: newTestCoreStringAfterDeadline(TcfPolicyVersion23),
+		DisclosedVendors: &DisclosedVendors{
+			SegmentType:      int(SegmentTypeDisclosedVendors),
+			MaxVendorId:      0,
+			IsRangeEncoding:  false,
+			DisclosedVendors: map[int]bool{},
+		},
+	}
+	err := data.Validate()
+	if err != nil {
+		t.Errorf("Validate() should return nil for v2.3 after deadline with DV, got: %s", err)
+	}
+}
+
+func TestValidateV22AfterDeadline(t *testing.T) {
+	data := &TCData{
+		CoreString: newTestCoreStringAfterDeadline(4),
+	}
+	err := data.Validate()
+	if err == nil {
+		t.Errorf("Validate() should return error for v2.2 after deadline")
+		return
+	}
+	expected := "TCF v2.3: TC Strings created after 2026-02-28 must have policyVersion >= 5"
+	if err.Error() != expected {
+		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+func TestValidateV23BeforeDeadlineWithoutDV(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(TcfPolicyVersion23), // before deadline
+		DisclosedVendors: nil,
+	}
+	err := data.Validate()
+	if err != nil {
+		t.Errorf("Validate() should return nil for v2.3 before deadline without DV, got: %s", err)
+	}
+}
+
+func TestValidateV22BeforeDeadlineWithoutDV(t *testing.T) {
+	data := &TCData{
+		CoreString:       newTestCoreString(4), // before deadline
+		DisclosedVendors: nil,
+	}
+	err := data.Validate()
+	if err != nil {
+		t.Errorf("Validate() should return nil for v2.2 before deadline without DV, got: %s", err)
+	}
+}
+
+func TestValidateNilCoreString(t *testing.T) {
+	data := &TCData{CoreString: nil}
+	err := data.Validate()
+	if err == nil {
+		t.Errorf("Validate() should return error for nil CoreString")
+		return
+	}
+	expected := "core string is required"
+	if err.Error() != expected {
+		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
+	}
+}
+
+// --- DecodeLenient() tests ---
+
+// Test: DecodeLenient with v2.3 after deadline without DV → succeeds
+func TestDecodeLenientV23AfterDeadlineWithoutDV(t *testing.T) {
+	core := newTestCoreStringAfterDeadline(TcfPolicyVersion23)
+	tcString := core.Encode()
+
+	data, err := DecodeLenient(tcString)
+	if err != nil {
+		t.Errorf("DecodeLenient() should succeed for v2.3 after deadline without DV: %s", err)
+		return
+	}
+	if data.CoreString == nil {
+		t.Errorf("DecodeLenient() should return non-nil CoreString")
+	}
+}
+
+// Test: DecodeLenient invalid string → fails
+func TestDecodeLenientInvalidString(t *testing.T) {
+	_, err := DecodeLenient("!!!invalid!!!")
+	if err == nil {
+		t.Errorf("DecodeLenient() should return error for invalid string")
+	}
+}
+
+// Test: DecodeLenient v2.2 before deadline without DV → succeeds
+func TestDecodeLenientV22BeforeDeadlineWithoutDV(t *testing.T) {
+	core := newTestCoreString(4)
+	tcString := core.Encode()
+
+	data, err := DecodeLenient(tcString)
+	if err != nil {
+		t.Errorf("DecodeLenient() should succeed for v2.2 before deadline without DV: %s", err)
+		return
+	}
+	if data.CoreString.TcfPolicyVersion != 4 {
+		t.Errorf("CoreString.TcfPolicyVersion = %d, want 4", data.CoreString.TcfPolicyVersion)
+	}
+}
+
+// --- Round-trip encode/decode test ---
+
+// Test: Round-trip encode/decode
+func TestRoundTripEncodeDecode(t *testing.T) {
+	core := newTestCoreString(TcfPolicyVersion23)
+	dv := &DisclosedVendors{
+		SegmentType:      int(SegmentTypeDisclosedVendors),
+		MaxVendorId:      10,
+		IsRangeEncoding:  false,
+		DisclosedVendors: map[int]bool{1: true, 5: true, 10: true},
+	}
+	data := &TCData{
+		CoreString:       core,
+		DisclosedVendors: dv,
+	}
+
+	tcString := data.ToTCString()
+	decoded, err := Decode(tcString)
+	if err != nil {
+		t.Errorf("Decode() should succeed for round-trip: %s", err)
+		return
+	}
+
+	if decoded.CoreString.TcfPolicyVersion != TcfPolicyVersion23 {
+		t.Errorf("Round-trip TcfPolicyVersion = %d, want %d", decoded.CoreString.TcfPolicyVersion, TcfPolicyVersion23)
+	}
+	if decoded.DisclosedVendors == nil {
+		t.Errorf("Round-trip should have DisclosedVendors")
+	}
+}
+
+// --- Encode tests (kept from original) ---
+
+// Test: Encode v2.3 mandatory DV
 func TestEncodeV23MandatoryDisclosedVendors(t *testing.T) {
 	data := &TCData{
-		CoreString:       newTestCoreString(TcfPolicyVersion23), // policyVersion=5
-		DisclosedVendors: nil,                                    // nil - should be auto-created
+		CoreString:       newTestCoreString(TcfPolicyVersion23),
+		DisclosedVendors: nil,
 	}
 
 	result := data.ToTCString()
@@ -102,12 +450,10 @@ func TestEncodeV23MandatoryDisclosedVendors(t *testing.T) {
 		t.Errorf("ToTCString() should produce at least 2 segments for v2.3 (Core + DV), got %d segments: %s", segments, result)
 	}
 
-	// Verify DisclosedVendors was auto-created on the TCData struct
 	if data.DisclosedVendors == nil {
 		t.Errorf("ToTCString() should auto-create DisclosedVendors for v2.3")
 	}
 
-	// Verify the second segment is DisclosedVendors
 	segParts := strings.Split(result, ".")
 	if len(segParts) >= 2 {
 		segType, err := GetSegmentType(segParts[1])
@@ -119,13 +465,11 @@ func TestEncodeV23MandatoryDisclosedVendors(t *testing.T) {
 	}
 }
 
-// --- Test 4: Encode v2.2 optional DV ---
-// Create TCData with Version=2, TcfPolicyVersion=4, DisclosedVendors=nil.
-// Verify ToTCString() produces only 1 segment (Core only).
+// Test: Encode v2.2 optional DV
 func TestEncodeV22OptionalDisclosedVendors(t *testing.T) {
 	data := &TCData{
-		CoreString:       newTestCoreString(4), // policyVersion=4 (pre-v2.3)
-		DisclosedVendors: nil,                  // nil - should NOT be auto-created
+		CoreString:       newTestCoreString(4),
+		DisclosedVendors: nil,
 	}
 
 	result := data.ToTCString()
@@ -136,80 +480,9 @@ func TestEncodeV22OptionalDisclosedVendors(t *testing.T) {
 	}
 }
 
-// --- Test 5: Validate() v2.3 missing DV ---
-// Test Validate() returns error for v2.3 without DV.
-func TestValidateV23MissingDisclosedVendors(t *testing.T) {
-	data := &TCData{
-		CoreString:       newTestCoreString(TcfPolicyVersion23),
-		DisclosedVendors: nil,
-	}
+// --- Constants test ---
 
-	err := data.Validate()
-	if err == nil {
-		t.Errorf("Validate() should return error for v2.3 without DisclosedVendors")
-		return
-	}
-
-	expected := "TCF v2.3: DisclosedVendors segment is mandatory for policyVersion >= 5"
-	if err.Error() != expected {
-		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
-	}
-}
-
-// --- Test 6: Validate() v2.3 with DV ---
-// Test Validate() returns nil for v2.3 with DV.
-func TestValidateV23WithDisclosedVendors(t *testing.T) {
-	data := &TCData{
-		CoreString: newTestCoreString(TcfPolicyVersion23),
-		DisclosedVendors: &DisclosedVendors{
-			SegmentType:      int(SegmentTypeDisclosedVendors),
-			MaxVendorId:      0,
-			IsRangeEncoding:  false,
-			DisclosedVendors: map[int]bool{},
-		},
-	}
-
-	err := data.Validate()
-	if err != nil {
-		t.Errorf("Validate() should return nil for v2.3 with DisclosedVendors, got: %s", err)
-	}
-}
-
-// --- Test 7: Validate() v2.2 without DV ---
-// Test Validate() returns nil for v2.2 without DV.
-func TestValidateV22WithoutDisclosedVendors(t *testing.T) {
-	data := &TCData{
-		CoreString:       newTestCoreString(4), // policyVersion=4
-		DisclosedVendors: nil,
-	}
-
-	err := data.Validate()
-	if err != nil {
-		t.Errorf("Validate() should return nil for v2.2 without DisclosedVendors, got: %s", err)
-	}
-}
-
-// --- Test 8: Validate() nil CoreString ---
-// Test Validate() returns error for nil CoreString.
-func TestValidateNilCoreString(t *testing.T) {
-	data := &TCData{
-		CoreString: nil,
-	}
-
-	err := data.Validate()
-	if err == nil {
-		t.Errorf("Validate() should return error for nil CoreString")
-		return
-	}
-
-	expected := "core string is required"
-	if err.Error() != expected {
-		t.Errorf("Validate() error = %q, want %q", err.Error(), expected)
-	}
-}
-
-// --- Test 9: Constants ---
-// Verify TcfPolicyVersion23=5 and TcfVersion23=2.
+// Test: Verify TcfV23Deadline constant value = 1772236800
 func TestV23Constants(t *testing.T) {
 	if TcfPolicyVersion23 != 5 {
 		t.Errorf("TcfPolicyVersion23 = %d, want 5", TcfPolicyVersion23)
@@ -217,5 +490,16 @@ func TestV23Constants(t *testing.T) {
 
 	if TcfVersion23 != 2 {
 		t.Errorf("TcfVersion23 = %d, want 2", TcfVersion23)
+	}
+
+	if TcfV23Deadline != 1772236800 {
+		t.Errorf("TcfV23Deadline = %d, want 1772236800", TcfV23Deadline)
+	}
+
+	// Verify the constant corresponds to Feb 28, 2026 00:00:00 UTC
+	deadlineTime := time.Unix(TcfV23Deadline, 0).UTC()
+	expectedTime := time.Date(2026, 2, 28, 0, 0, 0, 0, time.UTC)
+	if !deadlineTime.Equal(expectedTime) {
+		t.Errorf("TcfV23Deadline time = %v, want %v", deadlineTime, expectedTime)
 	}
 }


### PR DESCRIPTION
## Summary

Minor fixes and additions for TCF v2.3 support, plus a new debugging tool.

### Bug fixes

- **`TcfV23Deadline` constant**: was set to Sept 2023, updated to Feb 28, 2026 (matches the `v23Deadline` variable already in `tcdata.go`)
- **`Decode()` policy check**: the standalone `policyVersion >= 5 → DV mandatory` check was inconsistent with the deadline-based validation. Consolidated into a single deadline-based check that matches the spec timeline: before March 1, 2026 DV is optional, after Feb 28, 2026 both `policyVersion >= 5` and DV are required
- **`IsPurposeLIAllowed(1)`**: minor correction for v2.3 strings — Purpose 1 cannot rely on legitimate interest when `TcfPolicyVersion >= 5`

### New features

- **`DecodeLenient()`**: decodes any well-formed TC string without enforcing v2.3 compliance rules. Useful for **debugging, logging, and forensic analysis** of non-compliant strings (e.g. inspecting contents before rejecting). See README for usage and caveats.
- **`IsVendorDisclosed(id int) bool`**: convenience method on `TCData` and `DisclosedVendors` to check if a vendor is present in the DisclosedVendors segment
- **`IsV23() bool`**: helper to check if a decoded TC string follows v2.3 policy rules (`TcfPolicyVersion >= 5`)
- **`Validate()`**: existing method updated to match `Decode()` deadline-based policy

### Documentation

- Updated README with `DecodeLenient()` usage and warning (debug only, not for production consent decisions)
- Added TCF v2.3 enforcement policy table
- Documented new methods (`IsV23`, `IsVendorDisclosed`, `TcfV23Deadline` constant)

### Tests

- 40 tests passing (original + new v2.3 coverage)
- Coverage includes: deadline-based Decode policy, DecodeLenient, IsVendorDisclosed (bitfield + range), IsPurposeLIAllowed(1) v2.3, IsV23, Validate, round-trip encode/decode

### Backward compatibility

- `Decode()` behavior only changes for edge cases that were already inconsistent (standalone policyVersion check vs deadline check)
- No breaking API changes — all new functions are additions